### PR TITLE
Fix NPE that was preventing shutdown of game and notificati…

### DIFF
--- a/megamek/src/com/netbattletech/nbt/ILobby.java
+++ b/megamek/src/com/netbattletech/nbt/ILobby.java
@@ -5,6 +5,7 @@ public interface ILobby {
     IPlayer owner();
     int playerCount();
     IPlayer player(int index);
+    String serverUrl();
     int lowerLimit();
     int upperLimit();
     void addPlayer(IPlayer player);

--- a/megamek/src/com/netbattletech/nbt/LobbySessionController.java
+++ b/megamek/src/com/netbattletech/nbt/LobbySessionController.java
@@ -143,13 +143,15 @@ public class LobbySessionController extends WebSocketClient implements ISessionV
 
                     if (response.command.equals("join")) {
                         Lobby l = (Lobby) response.content;
+                        currentServerUrl = l.getServerUrl();
                         lobbyDataModel = new LobbyData(l, getAttachment());
                         mode = Mode.LOBBY_MODE;
 
-                        // recalculate lobby data model state
-                        updateLobbyDataModel();
-
                         view.activateLobbyView(lobbyDataModel, this);
+
+                        // recalculate lobby data model state and refresh the view
+                        updateLobbyDataModel();
+                        view.updateActiveView();
                     }
 
                     if (response.command.equals("list")) {
@@ -248,6 +250,7 @@ public class LobbySessionController extends WebSocketClient implements ISessionV
         enableLaunch &= owner.ready();
 
         lobbyDataModel.setLaunchEnabled(enableLaunch);
+        lobbyDataModel.setRejoinEnabled(lobbyDataModel.lobby().serverUrl() != null);
     }
 
     public void requestLobbyListing() {

--- a/megamek/src/com/netbattletech/nbt/model/Lobby.java
+++ b/megamek/src/com/netbattletech/nbt/model/Lobby.java
@@ -13,6 +13,7 @@ public class Lobby implements ILobby {
     private Integer id;
     private Integer leagueId;
     private Player owner;
+    String serverUrl;
     private List<Player> players = new ArrayList<>();
     private Integer upperLimit;
     private Integer lowerLimit = 0;
@@ -30,6 +31,10 @@ public class Lobby implements ILobby {
 
     public Integer getLeagueId() {
         return leagueId;
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public void setLeagueId(Integer leagueId) {
@@ -133,6 +138,11 @@ public class Lobby implements ILobby {
         }
 
         return getPlayers().get(index);
+    }
+
+    @Override
+    public String serverUrl() {
+        return getServerUrl();
     }
 
     @Override

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -253,6 +253,9 @@ public class Client extends WebSocketClient implements IClientCommandHandler {
      */
     public boolean connect() {
         if (serverUrl != null) {
+            // put something non-null in here so that we can exit gracefully on
+            // disconnect
+            host = "nbt-mm";
             return connect(serverUrl);
         } else {
             return connect(host, port);


### PR DESCRIPTION
Fixes #1 

When using `serverUrl` form of establishing server connection, the `host` variable was being left null, but was later checked for equality against "localhost", which caused a null-pointer exception that skipped running the normal game-dialog shutdown and "you have been disconnected" message. This PR gives `host` a value so that doesn't happen and things can proceed normally.